### PR TITLE
Add link to latest Visual Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,24 @@ node ./test/test.js
 ```
 
 On Windows, you'll need to install some dependencies first:
- - [node-gyp](https://github.com/TooTallNate/node-gyp/) (`npm install -g node-gyp`)
-   - [Python 2.7](http://www.python.org/download/releases/2.7.3#download) (not 3.3)
-   - Vistual Studio 2010 or higher (including Express editions)
-     - Windows XP/Vista/7:
-        - Microsoft Visual Studio C++ 2010 ([Express](http://go.microsoft.com/?linkid=9709949) version works well)
-        - For 64-bit builds of node and native modules you will _**also**_ need the [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279)
-        - If you get errors that the 64-bit compilers are not installed you may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
-     - Windows 8:
-        - Microsoft Visual Studio C++ 2012 for Windows Desktop ([Express](http://go.microsoft.com/?linkid=9816758) version works well)
  - [OpenSSL](http://slproweb.com/products/Win32OpenSSL.html) (normal, not light)
 in the same bitness as your Node.js installation.
   - The build script looks for OpenSSL in the default install directory  
   (`C:\OpenSSL-Win32` or `C:\OpenSSL-Win64`)
   - If you get `Error: The specified module could not be found.`, copy `libeay32.dll` from the OpenSSL bin directory to this module's bin directory, or to Windows\System3.
+ - [node-gyp](https://github.com/TooTallNate/node-gyp/) (`npm install -g node-gyp`)
+   - [Python 2.7](http://www.python.org/download/releases/2.7.3#download) (not 3.3)
+   - Microsoft Visual Studio C++ _**(either of the two below but not both)**_
+        - `Microsoft Visual Studio C++ 2013 for Windows Desktop` ([Express](http://www.microsoft.com/en-au/download/details.aspx?id=40787) version works well)
+            - No extra patches should be needed, but requires a fully up-to-date machine including all of the latest service packs
+        - Older versions of Visual Studio
+            - Windows XP/Vista/7:
+                - `Microsoft Visual Studio C++ 2010` ([Express](http://go.microsoft.com/?linkid=9709949) version works well)
+                    - For 64-bit builds of node and native modules you will _**also**_ need the [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279)
+                    - If you get errors that the 64-bit compilers are not installed you may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
+            - Windows 8:
+                - `Microsoft Visual Studio C++ 2012 for Windows Desktop` ([Express](http://go.microsoft.com/?linkid=9816758) version works well)
+
 
 Usage
 -----


### PR DESCRIPTION
Simplified the list, linked to VS2013. I have found using this version removed the need to install all of those patches. It has also worked on machines where the VS2010 and 2012 refused to allow ursa to compile.

This change should make installation easier and clearer.
