### PR TITLE
Add PrivateKey.getPrivateExponent().

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,38 +35,38 @@ Simple Encrypt / Decrypt Example
 ```javascript
 // openssl genrsa -out certs/server/my-server.key.pem 2048
 // openssl rsa -in certs/server/my-server.key.pem -pubout -out certs/client/my-server.pub
- 
+
 'use strict';
- 
+
 var fs = require('fs')
   , ursa = require('ursa')
   , crt
   , key
   , msg
   ;
- 
+
 key = ursa.createPrivateKey(fs.readFileSync('./certs/server/my-server.key.pem'));
 crt = ursa.createPublicKey(fs.readFileSync('./certs/client/my-server.pub'));
- 
+
 console.log('Encrypt with Public');
 msg = crt.encrypt("Everything is going to be 200 OK", 'utf8', 'base64');
 console.log('encrypted', msg, '\n');
- 
+
 console.log('Decrypt with Private');
 msg = key.decrypt(msg, 'base64', 'utf8');
 console.log('decrypted', msg, '\n');
- 
+
 console.log('############################################');
 console.log('Reverse Public -> Private, Private -> Public');
 console.log('############################################\n');
- 
+
 crt = ursa.createPrivateKey(fs.readFileSync('./certs/server/my-server.key.pem'));
 key = ursa.createPublicKey(fs.readFileSync('./certs/client/my-server.pub'));
- 
+
 console.log('Encrypt with Private (called public)');
 msg = key.encrypt("Everything is going to be 200 OK", 'utf8', 'base64');
 console.log('encrypted', msg, '\n');
- 
+
 console.log('Decrypt with Public (called private)');
 msg = crt.decrypt(msg, 'base64', 'utf8');
 console.log('decrypted', msg, '\n');
@@ -419,6 +419,11 @@ If no padding mode is specified, the default, and recommended, mode
 is `ursa.RSA_PKCS1_OAEP_PADDING`. The mode
 `ursa.RSA_PKCS1_PADDING` is also supported.
 
+### getPrivateExponent(encoding)
+
+Get the private exponent as an unsigned big-endian byte sequence. The returned
+exponent is not encrypted in any way, so this method should be used with caution. 
+
 ### hashAndSign(algorithm, buf, bufEncoding, outEncoding)
 
 This is a friendly wrapper for producing signatures. The given buffer
@@ -545,7 +550,7 @@ License
 Updates Copyright 2014 [NodePrime, Inc.](http://nodeprime.com/).
 Original Copyright 2012 [The Obvious Corporation](http://obvious.com/).
 
-Licensed under the Apache License, Version 2.0. 
+Licensed under the Apache License, Version 2.0.
 See the top-level file `[LICENSE.txt](LICENSE.txt)` and
 (http://www.apache.org/licenses/LICENSE-2.0).
 

--- a/lib/ursa.js
+++ b/lib/ursa.js
@@ -43,7 +43,7 @@ var UTF8 = "utf8";
 var MD5 = "md5";
 
 /** regex that matches PEM files, capturing the file type */
-var PEM_REGEX = 
+var PEM_REGEX =
     /^(-----BEGIN (.*) KEY-----\r?\n[:\s,-\/+=a-zA-Z0-9\r\n]*\r?\n-----END \2 KEY-----\r?\n)/m;
 
 /** "unsealer" key object to authenticate objects */
@@ -78,7 +78,7 @@ function identifyPemType(buf) {
 }
 
 /**
- * Return whether the given buffer or string appears (trivially) to be a 
+ * Return whether the given buffer or string appears (trivially) to be a
  * valid public key file in PEM format.
  */
 function isPublicKeyPem(buf) {
@@ -87,7 +87,7 @@ function isPublicKeyPem(buf) {
 }
 
 /**
- * Return whether the given buffer or string appears (trivially) to be a 
+ * Return whether the given buffer or string appears (trivially) to be a
  * valid private key file in PEM format.
  */
 function isPrivateKeyPem(buf) {
@@ -107,7 +107,7 @@ function toSshBigint(value) {
     var length = value.length + (prefix00 ? 1 : 0);
     var result = new Buffer(length + 4);
     var offset = 0;
-	
+
     result.writeUInt32BE(length, offset);
     offset += 4;
 
@@ -223,14 +223,14 @@ function openSshPublicKey(key, encoding) {
             parts.push(data);
             if (!(--partsLength)) break;
         }
-        
+
         return {
             modulus :   parts[2],
             exponent:   parts[1],
             type    :   parts[0]
         };
     }
-    
+
     var pubKey = parsePublicKey(key);
     var rsa = new RsaWrap();
 
@@ -239,7 +239,7 @@ function openSshPublicKey(key, encoding) {
     }
 
     rsa.openPublicSshKey(pubKey.modulus, pubKey.exponent);
-    
+
     return PublicKey(rsa);
 }
 
@@ -298,7 +298,7 @@ function PublicKey(rsa) {
     function unseal(unsealer) {
         return (unsealer === theUnsealer) ? self : undefined;
     }
-    
+
     self = {
         encrypt:                encrypt,
         getExponent:            getExponent,
@@ -322,6 +322,10 @@ function PublicKey(rsa) {
  */
 function PrivateKey(rsa) {
     var self;
+
+    function getPrivateExponent(encoding) {
+        return encodeBuffer(rsa.getPrivateExponent(), encoding);
+    }
 
     function toPrivatePem(encoding) {
         return encodeBuffer(rsa.getPrivateKeyPem(), encoding);
@@ -357,6 +361,7 @@ function PrivateKey(rsa) {
 
     self = PublicKey(rsa);
     self.decrypt                = decrypt;
+    self.getPrivateExponent     = getPrivateExponent;
     self.hashAndSign            = hashAndSign;
     self.privateEncrypt         = privateEncrypt;
     self.sign                   = sign;
@@ -593,7 +598,7 @@ function matchingPublicKeys(key1, key2) {
     // This isn't the most efficient implementation, but it will suffice:
     // We convert both to ssh form, which has very little leeway for
     // variation, and compare bytes.
-    
+
     var ssh1 = key1.toPublicSsh(UTF8);
     var ssh2 = key2.toPublicSsh(UTF8);
 

--- a/src/ursaNative.cc
+++ b/src/ursaNative.cc
@@ -531,7 +531,7 @@ NAN_METHOD(RsaWrap::GetPrivateExponent) {
     obj = expectPrivateKey(obj);
     if (obj == NULL) { NanReturnUndefined(); }
 
-    return bignumToBuffer(obj->rsa->d);
+    NanReturnValue(bignumToBuffer(obj->rsa->d));
 }
 
 /**

--- a/src/ursaNative.cc
+++ b/src/ursaNative.cc
@@ -524,11 +524,12 @@ NAN_METHOD(RsaWrap::GeneratePrivateKey) {
  * order. The returned exponent is not encrypted in any way,
  * so this should be used with caution.
  */
-Handle<Value> RsaWrap::GetPrivateExponent(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::GetPrivateExponent) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectPrivateKey(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    obj = expectPrivateKey(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
     return bignumToBuffer(obj->rsa->d);
 }

--- a/src/ursaNative.h
+++ b/src/ursaNative.h
@@ -22,6 +22,7 @@ class RsaWrap : node::ObjectWrap {
     static v8::Handle<v8::Value> New(const v8::Arguments& args);
     static v8::Handle<v8::Value> GeneratePrivateKey(const v8::Arguments& args);
     static v8::Handle<v8::Value> GetExponent(const v8::Arguments& args);
+    static v8::Handle<v8::Value> GetPrivateExponent(const v8::Arguments& args);
     static v8::Handle<v8::Value> GetModulus(const v8::Arguments& args);
     static v8::Handle<v8::Value> GetPrivateKeyPem(const v8::Arguments& args);
     static v8::Handle<v8::Value> GetPublicKeyPem(const v8::Arguments& args);

--- a/test/native.js
+++ b/test/native.js
@@ -157,19 +157,18 @@ function test_fail_getModulus() {
 
 function test_getPrivateExponent() {
     var rsa = new RsaWrap();
-    rsa.setPrivateKeyPem(fixture.PRIVATE_KEY);
+    rsa.createPrivateKeyFromComponents(
+        fixture.PRIVATE_KEY_COMPONENTS.modulus,
+        fixture.PRIVATE_KEY_COMPONENTS.exponent,
+        fixture.PRIVATE_KEY_COMPONENTS.p,
+        fixture.PRIVATE_KEY_COMPONENTS.q,
+        fixture.PRIVATE_KEY_COMPONENTS.dp,
+        fixture.PRIVATE_KEY_COMPONENTS.dq,
+        fixture.PRIVATE_KEY_COMPONENTS.inverseQ,
+        fixture.PRIVATE_KEY_COMPONENTS.d);
+
     var value = rsa.getPrivateExponent();
     assert.equal(value.toString(fixture.HEX), fixture.PRIVATE_KEY_COMPONENTS.d.toString(fixture.HEX));
-}
-
-function test_fail_getPrivateExponent() {
-    var rsa = new RsaWrap();
-    rsa.setPrivateKeyPem(fixture.PRIVATE_KEY);
-
-    function f1() {
-        rsa.getPrivateExponent();
-    }
-    assert.throws(f1, /Key not yet set\./);
 }
 
 function test_getPrivateKeyPem() {
@@ -643,7 +642,6 @@ function test() {
     test_new();
 
     test_getPrivateExponent();
-    test_fail_getPrivateExponent();
     test_setPrivateKeyPem();
     test_fail_setPrivateKeyPem();
     test_setPublicKeyPem();

--- a/test/native.js
+++ b/test/native.js
@@ -155,6 +155,23 @@ function test_fail_getModulus() {
     assert.throws(f1, /Key not yet set\./);
 }
 
+function test_getPrivateExponent() {
+    var rsa = new RsaWrap();
+    rsa.setPrivateKeyPem(fixture.PRIVATE_KEY);
+    var value = rsa.getPrivateExponent();
+    assert.equal(value.toString(fixture.HEX), fixture.PRIVATE_KEY_COMPONENTS.d.toString(fixture.HEX));
+}
+
+function test_fail_getPrivateExponent() {
+    var rsa = new RsaWrap();
+    rsa.setPrivateKeyPem(fixture.PRIVATE_KEY);
+
+    function f1() {
+        rsa.getPrivateExponent();
+    }
+    assert.throws(f1, /Key not yet set\./);
+}
+
 function test_getPrivateKeyPem() {
     var keyStr = fixture.PRIVATE_KEY.toString(fixture.UTF8);
 
@@ -392,7 +409,7 @@ function test_generatePrivateKey() {
     encoded = pubKey.publicEncrypt(plainBuf, ursaNative.RSA_PKCS1_OAEP_PADDING);
     decoded = rsa.privateDecrypt(encoded, ursaNative.RSA_PKCS1_OAEP_PADDING).toString(fixture.UTF8);
     assert.equal(decoded, fixture.PLAINTEXT);
-    
+
     // Similarly, try decoding with an extracted private key.
     var privKey = new RsaWrap();
     privKey.setPrivateKeyPem(rsa.getPrivateKeyPem());
@@ -625,6 +642,8 @@ function test_fail_textToNid() {
 function test() {
     test_new();
 
+    test_getPrivateExponent();
+    test_fail_getPrivateExponent();
     test_setPrivateKeyPem();
     test_fail_setPrivateKeyPem();
     test_setPublicKeyPem();


### PR DESCRIPTION
Gets the private exponent, or d value, from a private key. In the same category as PrivateKey.toPrivatePem().

I apologize for any slight formatting changes (trailing whitespace), it was done automatically.