### PR TITLE
Port ursa to NAN for compatibility with various nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 ursaNative.node
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 ursaNative.node
 node_modules
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "0.12"
   - "0.10"
   - iojs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
+  - "0.11"
   - "0.10"
+  - iojs

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,7 @@
 	},
 	'targets': [
 		{
+			'include_dirs': [ "<!(node -e \"require('nan')\")" ],
 			'target_name': 'ursaNative',
 			'sources': [ 'src/ursaNative.cc', 'src/asprintf.cc' ],
 			'conditions': [
@@ -22,7 +23,7 @@
 					  },
 					}],
 				  ],
-				  'libraries': [ 
+				  'libraries': [
 					'-l<(openssl_root)/lib/libeay32.lib',
 				  ],
 				  'include_dirs': [
@@ -37,7 +38,7 @@
 					}]
 					]
 				}],
-			
+
 			]
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -1,39 +1,53 @@
 {
-    "name": "ursa",
-    "version": "0.8.1",
-    "keywords": [
-        "crypto", "key", "openssl", "private", "public", "rsa", "sign",
-        "signature", "verify", "verification", "hash", "digest"
-    ],
-    "description":
-        "RSA public/private key OpenSSL bindings for Node.js",
-    "homepage": "https://github.com/NodePrime/ursa",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/NodePrime/ursa.git"
-    },
-    "licenses": [ {
-        "type": "Apache 2.0",
-        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    } ],
-    "author": {
-        "name": "Dan Bornstein",
-        "email": "danfuzz@milk.com",
-        "url": "http://www.milk.com/"
-    },
-    "maintainers": [ {
-        "name": "Jeremie Miller",
-        "email": "jeremie@jabber.org",
-        "url": "http://jeremie.com/"
-    } ],
-
-    "main": "lib/ursa.js",
-    "engine": {
-        "node": ">=0.6.0"
-    },
-
-    "scripts": {
-        "install": "node-gyp configure && node-gyp build && node install.js",
-        "test": "node test/test.js"
+  "name": "ursa",
+  "version": "0.8.1",
+  "keywords": [
+    "crypto",
+    "key",
+    "openssl",
+    "private",
+    "public",
+    "rsa",
+    "sign",
+    "signature",
+    "verify",
+    "verification",
+    "hash",
+    "digest"
+  ],
+  "description": "RSA public/private key OpenSSL bindings for Node.js",
+  "homepage": "https://github.com/NodePrime/ursa",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NodePrime/ursa.git"
+  },
+  "licenses": [
+    {
+      "type": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     }
+  ],
+  "author": {
+    "name": "Dan Bornstein",
+    "email": "danfuzz@milk.com",
+    "url": "http://www.milk.com/"
+  },
+  "maintainers": [
+    {
+      "name": "Jeremie Miller",
+      "email": "jeremie@jabber.org",
+      "url": "http://jeremie.com/"
+    }
+  ],
+  "main": "lib/ursa.js",
+  "engine": {
+    "node": ">=0.6.0"
+  },
+  "scripts": {
+    "install": "node-gyp configure && node-gyp build && node install.js",
+    "test": "node test/test.js"
+  },
+  "dependencies": {
+    "nan": "~1.6.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "test": "node test/test.js"
   },
   "dependencies": {
-    "nan": "~1.6.1"
+    "nan": "~1.6.2"
   }
 }

--- a/src/ursaNative.cc
+++ b/src/ursaNative.cc
@@ -427,6 +427,8 @@ RsaWrap *RsaWrap::expectUnset(RsaWrap* obj) {
  * Construct an empty instance.
  */
 NAN_METHOD(RsaWrap::New) {
+    NanScope();
+
     RsaWrap *obj = new RsaWrap();
     obj->Wrap(args.This());
 

--- a/src/ursaNative.cc
+++ b/src/ursaNative.cc
@@ -42,7 +42,7 @@ void init(Handle<Object> target) {
     BIND(target, textToNid, TextToNid);
     RsaWrap::InitClass(target);
 
-#ifdef _WIN32 
+#ifdef _WIN32
     // On Windows, we can't use Node's OpenSSL, so we link
     // to a standalone OpenSSL library. Therefore, we need
     // to initialize OpenSSL separately.
@@ -363,12 +363,12 @@ Handle<Value> TextToNid(const Arguments& args) {
     HandleScope scope;
 
     char *name = getArgString(args, 0);
-    if (name == NULL) { return Undefined(); }        
+    if (name == NULL) { return Undefined(); }
 
     int nid = OBJ_txt2nid(name);
     free(name);
 
-    if (nid == NID_undef) { 
+    if (nid == NID_undef) {
         scheduleSslException();
         return Undefined();
     }
@@ -623,7 +623,7 @@ Handle<Value> RsaWrap::GetPrivateKeyPem(const Arguments& args) {
         return Undefined();
     }
 
-    char *password = NULL; 
+    char *password = NULL;
     int passwordLen = 0;
     const EVP_CIPHER *cipher = NULL;
 
@@ -640,8 +640,8 @@ Handle<Value> RsaWrap::GetPrivateKeyPem(const Arguments& args) {
     }
 
 
-    if (!PEM_write_bio_RSAPrivateKey(bio, obj->rsa, 
-                                     cipher, (unsigned char *)password, 
+    if (!PEM_write_bio_RSAPrivateKey(bio, obj->rsa,
+                                     cipher, (unsigned char *)password,
                                      passwordLen, NULL, NULL)) {
         scheduleSslException();
         BIO_vfree(bio);
@@ -742,7 +742,7 @@ Handle<Value> RsaWrap::PrivateEncrypt(const Arguments& args) {
         return Undefined();
     }
 
-    int ret = RSA_private_encrypt(length, (unsigned char *) data, 
+    int ret = RSA_private_encrypt(length, (unsigned char *) data,
                                   (unsigned char *) node::Buffer::Data(result),
                                   obj->rsa, RSA_PKCS1_PADDING);
 
@@ -816,7 +816,7 @@ Handle<Value> RsaWrap::PublicEncrypt(const Arguments& args) {
     int padding;
     if (!getArgInt(args, 1, &padding)) { return Undefined(); }
 
-    int ret = RSA_public_encrypt(length, (unsigned char *) data, 
+    int ret = RSA_public_encrypt(length, (unsigned char *) data,
                                  (unsigned char *) node::Buffer::Data(result),
                                  obj->rsa, padding);
 
@@ -906,11 +906,11 @@ Handle<Value> RsaWrap::Sign(const Arguments& args) {
     unsigned int sigLength = rsaSize;
     node::Buffer *result = node::Buffer::New(sigLength);
 
-    int ret = RSA_sign(nid, (unsigned char*) data, dataLength, 
+    int ret = RSA_sign(nid, (unsigned char*) data, dataLength,
                        (unsigned char *) node::Buffer::Data(result),
                        &sigLength, obj->rsa);
 
-    if (ret == 0) { 
+    if (ret == 0) {
         // TODO: Will this leak the result buffer? Is it going to be gc'ed?
         scheduleSslException();
         return Undefined();
@@ -1041,5 +1041,3 @@ Handle<Value> RsaWrap::CreatePrivateKeyFromComponents(const Arguments& args) {
 
     return Undefined();
 }
-
-

--- a/src/ursaNative.cc
+++ b/src/ursaNative.cc
@@ -30,8 +30,8 @@ using namespace v8;
  * Helper for prototype binding.
  */
 #define BIND(proto, highName, lowName) \
-    (proto)->Set(String::NewSymbol(#highName), \
-        FunctionTemplate::New(lowName)->GetFunction())
+    (proto)->Set(NanNew<String>(#highName), \
+        NanNew<FunctionTemplate>(lowName)->GetFunction())
 
 /**
  * Top-level initialization function.
@@ -68,10 +68,8 @@ NODE_MODULE(ursaNative, init)
  */
 static void scheduleSslException() {
     char *err = ERR_error_string(ERR_get_error(), NULL);
-    Local<Value> exception = Exception::Error(String::New(err));
-
     ERR_clear_error();
-    ThrowException(exception);
+    NanThrowError(err);
 }
 
 /**
@@ -80,7 +78,7 @@ static void scheduleSslException() {
  * best we can do in a bad situation.
  */
 static void scheduleAllocException() {
-    ThrowException(Exception::Error(String::New("Allocation failed.")));
+    NanThrowError("Allocation failed.");
 }
 
 /**
@@ -90,22 +88,14 @@ static void scheduleAllocException() {
  */
 static Handle<Value> bignumToBuffer(BIGNUM *number) {
     int length = BN_num_bytes(number);
-    node::Buffer *result = node::Buffer::New(length);
-
-    if (result == NULL) {
-        scheduleAllocException();
-        return Undefined();
-    }
+    Local<Object> result = NanNewBufferHandle(length);
 
     if (BN_bn2bin(number, (unsigned char *) node::Buffer::Data(result)) < 0) {
         scheduleSslException();
-        delete result;
-        return Undefined();
+        return NanUndefined();
     }
 
-    // TODO: Is there a more idiomatic way of getting a handle from
-    // a Buffer?
-    return result->handle_;
+    return result;
 }
 
 /**
@@ -119,77 +109,39 @@ static Handle<Value> bignumToBuffer(BIGNUM *number) {
  */
 static Handle<Value> bioToBuffer(BIO *bio) {
     if (bio == NULL) {
-        return Undefined();
+        return NanUndefined();
     }
 
     char *data;
     long length = BIO_get_mem_data(bio, &data);
-    node::Buffer *result = node::Buffer::New(length);
+    Local<Object> result = NanNewBufferHandle(length);
 
-    if (result == NULL) {
+    if (result.IsEmpty()) {
         scheduleAllocException();
         BIO_vfree(bio);
-        return Undefined();
+        return NanUndefined();
     }
 
     memcpy(node::Buffer::Data(result), data, length);
     BIO_vfree(bio);
 
-    // TODO: Is there a more idiomatic way of getting a handle from
-    // a Buffer?
-    return result->handle_;
+    return result;
 }
 
 /**
  * Check that the given argument index exists. Returns true if so.
  * Schedules an exception and returns false if not.
  */
-static bool hasArgument(const Arguments& args, int index) {
-    if (args.Length() > index) {
+static bool hasArgument(int length, int index) {
+    if (length > index) {
         return true;
     }
 
     char *message = NULL;
     if(asprintf(&message, "Missing args[%d].", index) < 0) { return false; }
-    ThrowException(Exception::TypeError(String::New(message)));
+    NanThrowError(message);
     free(message);
     return false;
-}
-
-/**
- * Check that the given argument index exists and is a Buffer. Returns
- * true if so. Schedules an exception and returns false if not.
- */
-static bool isBuffer(const Arguments& args, int index) {
-    if (!hasArgument(args, index)) { return false; }
-
-    if (!node::Buffer::HasInstance(args[index])) {
-        char *message = NULL;
-        if(asprintf(&message, "Expected a Buffer in args[%d].", index) < 0) { return false; }
-        ThrowException(Exception::TypeError(String::New(message)));
-        free(message);
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * Check that the given argument index exists and is a string. Returns
- * true if so. Schedules an exception and returns false if not.
- */
-static bool isString(const Arguments& args, int index) {
-    if (!hasArgument(args, index)) { return false; }
-
-    if (!args[index]->IsString()) {
-        char *message = NULL;
-        if(asprintf(&message, "Expected a string in args[%d].", index) < 0) { return false; }
-        ThrowException(Exception::TypeError(String::New(message)));
-        free(message);
-        return false;
-    }
-
-    return true;
 }
 
 /**
@@ -197,10 +149,7 @@ static bool isString(const Arguments& args, int index) {
  * memory BIO. Returns a non-null pointer on success. On failure,
  * schedules an exception and returns NULL.
  */
-static BIO *getArg0Bio(const Arguments& args) {
-    if (!isBuffer(args, 0)) { return NULL; }
-
-    Local<Object> buf = args[0]->ToObject();
+static BIO *getArg0Bio(const Local<Object> buf) {
     char *data = node::Buffer::Data(buf);
     ssize_t length = node::Buffer::Length(buf);
     BIO *bio = BIO_new_mem_buf(data, length);
@@ -210,10 +159,7 @@ static BIO *getArg0Bio(const Arguments& args) {
     return bio;
 }
 
-static BIGNUM *getArgXBigNum(int x, const Arguments& args) {
-    if (!isBuffer(args, x)) { return NULL; }
-
-    Local<Object> buf = args[x]->ToObject();
+static BIGNUM *getArgXBigNum(const Local<Object> buf) {
     char *data = node::Buffer::Data(buf);
     ssize_t length = node::Buffer::Length(buf);
 
@@ -222,30 +168,12 @@ static BIGNUM *getArgXBigNum(int x, const Arguments& args) {
 
 
 /**
- * Get a Buffer out of args[] at the given index, yielding a data
- * pointer and length.  Returns a non-null pointer on success and sets
- * the given length pointer. On failure, schedules an exception and
- * returns NULL.
- */
-static void *getArgDataAndLength(const Arguments& args, int index,
-                                 int *lengthPtr) {
-    if (!isBuffer(args, index)) { return NULL; }
-
-    Local<Object> buf = args[index]->ToObject();
-
-    *lengthPtr = node::Buffer::Length(buf);
-    return node::Buffer::Data(buf);
-}
-
-/**
  * Get a Buffer out of args[1], converted to a freshly-allocated (char
  * *). Returns a non-null pointer on success. On failure, schedules an
  * exception and returns NULL.
  */
-static char *getArg1BufferAsString(const Arguments& args) {
-    if (!isBuffer(args, 1)) { return NULL; }
+static char *copyBufferToCharStar(const Local<Object> buf) {
 
-    Local<Object> buf = args[1]->ToObject();
     char *data = node::Buffer::Data(buf);
     ssize_t length = node::Buffer::Length(buf);
     char *result = (char *) malloc(length + 1);
@@ -265,10 +193,8 @@ static char *getArg1BufferAsString(const Arguments& args) {
  * freshly-allocated (char *). Returns a non-null pointer on
  * success. On failure, schedules an exception and returns NULL.
  */
-static char *getArgString(const Arguments& args, int index) {
-    if (!isString(args, index)) { return NULL; }
-
-    Local<String> str = args[index]->ToString();
+static char *copyBufferToUtf8String(const Local<String> str) {
+// static char *getArgString(const Arguments& args, int index) {
     int length = str->Utf8Length();
     char *result = (char *) malloc(length + 1);
 
@@ -282,34 +208,12 @@ static char *getArgString(const Arguments& args, int index) {
 
     if (result[length] != '\0') {
         const char *message = "String conversion failed.";
-        ThrowException(Exception::Error(String::New(message)));
+        NanThrowError(message);
         free(result);
         return NULL;
     }
 
     return result;
-}
-
-/**
- * Get an int out of args at the given index, storing it into the
- * given pointer. Returns true on success. Schedules an exception and
- * returns false on failure.
- */
-static bool getArgInt(const Arguments& args, int index, int *resultPtr) {
-    if (!hasArgument(args, index)) { return false; }
-
-    Local<Value> arg = args[index];
-
-    if (! arg->IsInt32()) {
-        char *message = NULL;
-        if(asprintf(&message, "Expected a 32-bit integer in args[%d].", index) < 0) { return false; }
-        ThrowException(Exception::TypeError(String::New(message)));
-        free(message);
-        return false;
-    }
-
-    *resultPtr = (int) arg->ToInt32()->Value();
-    return true;
 }
 
 /**
@@ -359,21 +263,22 @@ static RSA *generateKey(int num, unsigned long e) {
  * (danfuzz) know, is not necessarily stable across versions of
  * OpenSSL, so it's only safe to use transiently.
  */
-Handle<Value> TextToNid(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(TextToNid) {
+    NanScope();
 
-    char *name = getArgString(args, 0);
-    if (name == NULL) { return Undefined(); }
+    Local<String> str = args[0].As<String>();
+    char *name = copyBufferToUtf8String(str);
+    if (name == NULL) { NanReturnUndefined(); }
 
     int nid = OBJ_txt2nid(name);
     free(name);
 
     if (nid == NID_undef) {
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
-    return scope.Close(Integer::New(nid));
+    NanReturnValue(NanNew<Number>(nid));
 }
 
 
@@ -385,10 +290,10 @@ Handle<Value> TextToNid(const Arguments& args) {
  * Initialize the bindings for this class.
  */
 void RsaWrap::InitClass(Handle<Object> target) {
-    Local<String> className = String::NewSymbol("RsaWrap");
+    Local<String> className = NanNew<String>("RsaWrap");
 
     // Basic instance setup
-    Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
+    Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(New);
 
     tpl->SetClassName(className);
     tpl->InstanceTemplate()->SetInternalFieldCount(1); // req'd by ObjectWrap
@@ -413,7 +318,7 @@ void RsaWrap::InitClass(Handle<Object> target) {
     BIND(proto, openPublicSshKey,   OpenPublicSshKey);
 
     // Store the constructor in the target bindings.
-    target->Set(className, Persistent<Function>::New(tpl->GetFunction()));
+    target->Set(NanNew("RsaWrap"), NanNew<FunctionTemplate>(New)->GetFunction());
 }
 
 /**
@@ -434,12 +339,13 @@ RsaWrap::~RsaWrap() {
     }
 }
 
-Handle<Value> RsaWrap::OpenPublicSshKey(const Arguments& args) {
-    HandleScope scope;
-    RsaWrap *obj = unwrapExpectUnset(args);
+NAN_METHOD(RsaWrap::OpenPublicSshKey) {
+    NanScope();
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectUnset(obj);
 
-    Local<Object> obj_n = args[0]->ToObject();
-    Local<Object> obj_e = args[1]->ToObject();
+    Local<Object> obj_n = args[0].As<Object>();
+    Local<Object> obj_e = args[1].As<Object>();
     int n_length = node::Buffer::Length(obj_n);
     int e_length = node::Buffer::Length(obj_e);
     unsigned char *data_n = (unsigned char *)malloc(n_length);
@@ -455,7 +361,7 @@ Handle<Value> RsaWrap::OpenPublicSshKey(const Arguments& args) {
     obj->rsa->e = BN_bin2bn(data_e, e_length, NULL);
     free(data_n);
     free(data_e);
-    return Undefined();
+    NanReturnUndefined();
 }
 
 /**
@@ -464,8 +370,8 @@ Handle<Value> RsaWrap::OpenPublicSshKey(const Arguments& args) {
  * key. Returns a non-null pointer on success. On failure, schedules
  * an exception and returns null.
  */
-RsaWrap *RsaWrap::unwrapExpectPrivateKey(const Arguments& args) {
-    RsaWrap *obj = unwrapExpectSet(args);
+RsaWrap* RsaWrap::expectPrivateKey(RsaWrap* obj) {
+    expectSet(obj);
 
     // The "d" field should always be set on a private key and never
     // set on a public key.
@@ -473,9 +379,7 @@ RsaWrap *RsaWrap::unwrapExpectPrivateKey(const Arguments& args) {
         return obj;
     }
 
-    Local<Value> exception =
-        Exception::Error(String::New("Expected a private key."));
-    ThrowException(exception);
+    NanThrowError("Expected a private key.");
     return NULL;
 }
 
@@ -484,15 +388,13 @@ RsaWrap *RsaWrap::unwrapExpectPrivateKey(const Arguments& args) {
  * (RSA *) to be non-null. Returns a non-null pointer on success. On failure,
  * schedules an exception and returns null.
  */
-RsaWrap *RsaWrap::unwrapExpectSet(const Arguments& args) {
-    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+RsaWrap *RsaWrap::expectSet(RsaWrap* obj) {
 
     if (obj->rsa != NULL) {
         return obj;
     }
 
-    Local<Value> exception = Exception::Error(String::New("Key not yet set."));
-    ThrowException(exception);
+    NanThrowError("Key not yet set.");
     return NULL;
 }
 
@@ -501,44 +403,38 @@ RsaWrap *RsaWrap::unwrapExpectSet(const Arguments& args) {
  * (RSA *) to be null. Returns a non-null pointer on success. On failure,
  * schedules an exception and returns null.
  */
-RsaWrap *RsaWrap::unwrapExpectUnset(const Arguments& args) {
-    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+RsaWrap *RsaWrap::expectUnset(RsaWrap* obj) {
 
     if (obj->rsa == NULL) {
         return obj;
     }
 
-    Local<Value> exception = Exception::Error(String::New("Key already set."));
-    ThrowException(exception);
+    NanThrowError("Key already set.");
     return NULL;
 }
 
 /**
  * Construct an empty instance.
  */
-Handle<Value> RsaWrap::New(const Arguments& args) {
+NAN_METHOD(RsaWrap::New) {
     RsaWrap *obj = new RsaWrap();
     obj->Wrap(args.This());
 
-    return args.This();
+    NanReturnValue(args.This());
 }
 
 /**
  * Set the underlying RSA struct to a newly-generated key pair.
  */
-Handle<Value> RsaWrap::GeneratePrivateKey(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::GeneratePrivateKey) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectUnset(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectUnset(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    int modulusBits = 0;
-    int exponent = 0;
-
-    if (! (getArgInt(args, 0, &modulusBits) &&
-           getArgInt(args, 1, &exponent))) {
-        return Undefined();
-    }
+    int modulusBits = args[0]->Uint32Value();
+    int exponent = args[1]->Uint32Value();
 
     // Sanity-check the arguments, since (as of this writing) OpenSSL
     // either doesn't check, or at least doesn't consistently check:
@@ -550,22 +446,18 @@ Handle<Value> RsaWrap::GeneratePrivateKey(const Arguments& args) {
     // * The exponend must be positive and odd.
 
     if (modulusBits < 512) {
-        Local<String> message =
-            String::New("Expected modulus bit count >= 512.");
-        ThrowException(Exception::TypeError(message));
-        return Undefined();
+        NanThrowError("Expected modulus bit count >= 512.");
+        NanReturnUndefined();
     }
 
     if (exponent <= 0) {
-        Local<String> message = String::New("Expected positive exponent.");
-        ThrowException(Exception::TypeError(message));
-        return Undefined();
+        NanThrowError("Expected positive exponent.");
+        NanReturnUndefined();
     }
 
     if ((exponent & 1) == 0) {
-        Local<String> message = String::New("Expected odd exponent.");
-        ThrowException(Exception::TypeError(message));
-        return Undefined();
+        NanThrowError("Expected odd exponent.");
+        NanReturnUndefined();
     }
 
     obj->rsa = generateKey(modulusBits, (unsigned long) exponent);
@@ -574,7 +466,7 @@ Handle<Value> RsaWrap::GeneratePrivateKey(const Arguments& args) {
         scheduleSslException();
     }
 
-    return Undefined();
+    NanReturnUndefined();
 }
 
 /**
@@ -582,13 +474,14 @@ Handle<Value> RsaWrap::GeneratePrivateKey(const Arguments& args) {
  * value is a Buffer containing the unsigned number in big-endian
  * order.
  */
-Handle<Value> RsaWrap::GetExponent(const Arguments& args) {
-    HandleScope scope;
+ NAN_METHOD(RsaWrap::GetExponent) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectSet(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectSet(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    return bignumToBuffer(obj->rsa->e);
+    NanReturnValue(bignumToBuffer(obj->rsa->e));
 }
 
 /**
@@ -596,13 +489,14 @@ Handle<Value> RsaWrap::GetExponent(const Arguments& args) {
  * value is a Buffer containing the unsigned number in big-endian
  * order.
  */
-Handle<Value> RsaWrap::GetModulus(const Arguments& args) {
-    HandleScope scope;
+ NAN_METHOD(RsaWrap::GetModulus) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectSet(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectSet(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    return bignumToBuffer(obj->rsa->n);
+    NanReturnValue(bignumToBuffer(obj->rsa->n));
 }
 
 /**
@@ -611,31 +505,35 @@ Handle<Value> RsaWrap::GetModulus(const Arguments& args) {
  * file contents (in ASCII / UTF8). Note: This does not do any
  * encryption of the results.
  */
-Handle<Value> RsaWrap::GetPrivateKeyPem(const Arguments& args) {
-    HandleScope scope;
+ NAN_METHOD(RsaWrap::GetPrivateKeyPem) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectPrivateKey(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectPrivateKey(obj);
+
+    if (obj == NULL) { NanReturnUndefined(); }
 
     BIO *bio = BIO_new(BIO_s_mem());
     if (bio == NULL) {
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
     char *password = NULL;
     int passwordLen = 0;
     const EVP_CIPHER *cipher = NULL;
 
-    if(args.Length() > 0) {
-      password = getArgString(args, 0);
+    if (args.Length() > 0) {
+      Local<String> pstr = args[0].As<String>();
+      password = copyBufferToUtf8String(pstr);
 
-      char *cipherName = getArgString(args, 1);
+      Local<String> cstr = args[1].As<String>();
+      char *cipherName = copyBufferToUtf8String(cstr);
       cipher = EVP_get_cipherbyname(cipherName);
       free(cipherName);
     }
 
-    if(password != NULL) {
+    if (password != NULL) {
       passwordLen = (int)strlen(password);
     }
 
@@ -646,11 +544,11 @@ Handle<Value> RsaWrap::GetPrivateKeyPem(const Arguments& args) {
         scheduleSslException();
         BIO_vfree(bio);
         free(password);
-        return Undefined();
+        NanReturnUndefined();
     }
 
     free(password);
-    return bioToBuffer(bio);
+    NanReturnValue(bioToBuffer(bio));
 }
 
 /**
@@ -658,25 +556,26 @@ Handle<Value> RsaWrap::GetPrivateKeyPem(const Arguments& args) {
  * in PEM format. The return value is a Buffer containing the
  * file contents (in ASCII / UTF8).
  */
-Handle<Value> RsaWrap::GetPublicKeyPem(const Arguments& args) {
-    HandleScope scope;
+ NAN_METHOD(RsaWrap::GetPublicKeyPem) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectSet(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectSet(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
     BIO *bio = BIO_new(BIO_s_mem());
     if (bio == NULL) {
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
     if (!PEM_write_bio_RSA_PUBKEY(bio, obj->rsa)) {
         scheduleSslException();
         BIO_vfree(bio);
-        return Undefined();
+        NanReturnUndefined();
     }
 
-    return bioToBuffer(bio);
+    NanReturnValue(bioToBuffer(bio));
 }
 
 /**
@@ -684,39 +583,34 @@ Handle<Value> RsaWrap::GetPublicKeyPem(const Arguments& args) {
  * must be a private key. This always uses the padding mode
  * RSA_PKCS1_OAEP_PADDING.
  */
-Handle<Value> RsaWrap::PrivateDecrypt(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::PrivateDecrypt) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectPrivateKey(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectPrivateKey(obj);
 
-    int length;
-    void *data = getArgDataAndLength(args, 0, &length);
-    if (data == NULL) { return Undefined(); }
+    if (obj == NULL) { NanReturnUndefined(); }
+
+    Local<Object> buffer = args[0].As<Object>();
+    size_t length = node::Buffer::Length(buffer);
+    char* data = node::Buffer::Data(buffer);
+    if (data == NULL) { NanReturnUndefined(); }
 
     int rsaLength = RSA_size(obj->rsa);
     VAR_ARRAY(unsigned char, buf, rsaLength);
 
-    int padding;
-    if (!getArgInt(args, 1, &padding)) { return Undefined(); }
-
+    int padding = args[1]->Uint32Value();
     int bufLength = RSA_private_decrypt(length, (unsigned char *) data,
                                         buf, obj->rsa, padding);
 
     if (bufLength < 0) {
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
-    node::Buffer *result = node::Buffer::New(bufLength);
-
-    if (result == NULL) {
-        scheduleAllocException();
-        return Undefined();
-    }
-
+    Local<Object> result = NanNewBufferHandle(bufLength);
     memcpy(node::Buffer::Data(result), buf, bufLength);
-    return result->handle_;
+    NanReturnValue(result);
 }
 
 /**
@@ -724,23 +618,20 @@ Handle<Value> RsaWrap::PrivateDecrypt(const Arguments& args) {
  * must be private. This always uses the padding mode
  * RSA_PKCS1_PADDING.
  */
-Handle<Value> RsaWrap::PrivateEncrypt(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::PrivateEncrypt) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectPrivateKey(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectPrivateKey(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    int length;
-    void *data = getArgDataAndLength(args, 0, &length);
-    if (data == NULL) { return Undefined(); }
+    Local<Object> buffer = args[0].As<Object>();
+    size_t length = node::Buffer::Length(buffer);
+    char* data = node::Buffer::Data(buffer);
+    if (data == NULL) { NanReturnUndefined(); }
 
     int rsaLength = RSA_size(obj->rsa);
-    node::Buffer *result = node::Buffer::New(rsaLength);
-
-    if (result == NULL) {
-        scheduleAllocException();
-        return Undefined();
-    }
+    Local<Object> result = NanNewBufferHandle(rsaLength);
 
     int ret = RSA_private_encrypt(length, (unsigned char *) data,
                                   (unsigned char *) node::Buffer::Data(result),
@@ -749,25 +640,27 @@ Handle<Value> RsaWrap::PrivateEncrypt(const Arguments& args) {
     if (ret < 0) {
         // TODO: Will this leak the result buffer? Is it going to be gc'ed?
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
-    return result->handle_;
+    NanReturnValue(result);
 }
 
 /**
  * Perform decryption on the given buffer using the (public aspect of
  * the) RSA key. This always uses the padding mode RSA_PKCS1_PADDING.
  */
-Handle<Value> RsaWrap::PublicDecrypt(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::PublicDecrypt) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectSet(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectSet(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    int length;
-    void *data = getArgDataAndLength(args, 0, &length);
-    if (data == NULL) { return Undefined(); }
+    Local<Object> buffer = args[0].As<Object>();
+    size_t length = node::Buffer::Length(buffer);
+    char* data = node::Buffer::Data(buffer);
+    if (data == NULL) { NanReturnUndefined(); }
 
     int rsaLength = RSA_size(obj->rsa);
     VAR_ARRAY(unsigned char, buf, rsaLength);
@@ -777,44 +670,33 @@ Handle<Value> RsaWrap::PublicDecrypt(const Arguments& args) {
 
     if (bufLength < 0) {
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
-    node::Buffer *result = node::Buffer::New(bufLength);
-
-    if (result == NULL) {
-        scheduleAllocException();
-        return Undefined();
-    }
-
+    Local<Object> result = NanNewBufferHandle(bufLength);
     memcpy(node::Buffer::Data(result), buf, bufLength);
-    return result->handle_;
+    NanReturnValue(result);
 }
 
 /**
  * Perform encryption on the given buffer using the public (aspect of the)
  * RSA key. This always uses the padding mode RSA_PKCS1_OAEP_PADDING.
  */
-Handle<Value> RsaWrap::PublicEncrypt(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::PublicEncrypt) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectSet(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectSet(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    int length;
-    void *data = getArgDataAndLength(args, 0, &length);
-    if (data == NULL) { return Undefined(); }
+    Local<Object> buffer = args[0].As<Object>();
+    size_t length = node::Buffer::Length(buffer);
+    char* data = node::Buffer::Data(buffer);
 
     int rsaLength = RSA_size(obj->rsa);
-    node::Buffer *result = node::Buffer::New(rsaLength);
+    Local<Object> result = NanNewBufferHandle(rsaLength);
 
-    if (result == NULL) {
-        scheduleAllocException();
-        return Undefined();
-    }
-
-    int padding;
-    if (!getArgInt(args, 1, &padding)) { return Undefined(); }
+    int padding = args[1]->Uint32Value();
 
     int ret = RSA_public_encrypt(length, (unsigned char *) data,
                                  (unsigned char *) node::Buffer::Data(result),
@@ -823,10 +705,10 @@ Handle<Value> RsaWrap::PublicEncrypt(const Arguments& args) {
     if (ret < 0) {
         // TODO: Will this leak the result buffer? Is it going to be gc'ed?
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
-    return result->handle_;
+    NanReturnValue(result);
 }
 
 /**
@@ -834,22 +716,24 @@ Handle<Value> RsaWrap::PublicEncrypt(const Arguments& args) {
  * private key (a Buffer of PEM format data). This throws an
  * exception if the underlying RSA had previously been set.
  */
-Handle<Value> RsaWrap::SetPrivateKeyPem(const Arguments& args) {
-    HandleScope scope;
+ NAN_METHOD(RsaWrap::SetPrivateKeyPem) {
+    NanScope();
     bool ok = true;
 
-    RsaWrap *obj = unwrapExpectUnset(args);
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectUnset(obj);
     ok &= (obj != NULL);
 
     BIO *bio = NULL;
     if (ok) {
-        bio = getArg0Bio(args);
+        bio = getArg0Bio(args[0].As<Object>());
         ok &= (bio != NULL);
     }
 
+    Local<Object> buf = args[1].As<Object>();
     char *password = NULL;
     if (ok && (args.Length() >= 2)) {
-        password = getArg1BufferAsString(args);
+        password = copyBufferToCharStar(buf);
         ok &= (password != NULL);
     }
 
@@ -860,7 +744,7 @@ Handle<Value> RsaWrap::SetPrivateKeyPem(const Arguments& args) {
 
     if (bio != NULL) { BIO_vfree(bio); }
     free(password);
-    return Undefined();
+    NanReturnUndefined();
 }
 
 /**
@@ -868,43 +752,45 @@ Handle<Value> RsaWrap::SetPrivateKeyPem(const Arguments& args) {
  * public key (a Buffer of PEM format data). This throws an
  * exception if the underlying RSA had previously been set.
  */
-Handle<Value> RsaWrap::SetPublicKeyPem(const Arguments& args) {
-    HandleScope scope;
+ NAN_METHOD(RsaWrap::SetPublicKeyPem) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectUnset(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectUnset(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    BIO *bio = getArg0Bio(args);
-    if (bio == NULL) { return Undefined(); }
+    BIO *bio = getArg0Bio(args[0].As<Object>());
+    if (bio == NULL) { NanReturnUndefined(); }
 
     obj->rsa = PEM_read_bio_RSA_PUBKEY(bio, NULL, NULL, NULL);
 
     if (obj->rsa == NULL) { scheduleSslException(); }
 
     BIO_vfree(bio);
-    return Undefined();
+    NanReturnUndefined();
 }
 
 /**
  * Sign the given hash data. First argument indicates what kind of hash
  * was performed. Returns a Buffer object.
  */
-Handle<Value> RsaWrap::Sign(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::Sign) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectPrivateKey(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectPrivateKey(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    int nid;
-    if (!getArgInt(args, 0, &nid)) { return Undefined(); }
+    int nid = args[0]->Uint32Value();
 
-    int dataLength;
-    void *data = getArgDataAndLength(args, 1, &dataLength);
-    if (data == NULL) { return Undefined(); }
+    Local<Object> buffer = args[1].As<Object>();
+    size_t dataLength = node::Buffer::Length(buffer);
+    char* data = node::Buffer::Data(buffer);
+    if (data == NULL) { NanReturnUndefined(); }
 
     unsigned int rsaSize = (unsigned int) RSA_size(obj->rsa);
     unsigned int sigLength = rsaSize;
-    node::Buffer *result = node::Buffer::New(sigLength);
+    Local<Object> result = NanNewBufferHandle(sigLength);
 
     int ret = RSA_sign(nid, (unsigned char*) data, dataLength,
                        (unsigned char *) node::Buffer::Data(result),
@@ -913,15 +799,15 @@ Handle<Value> RsaWrap::Sign(const Arguments& args) {
     if (ret == 0) {
         // TODO: Will this leak the result buffer? Is it going to be gc'ed?
         scheduleSslException();
-        return Undefined();
+        NanReturnUndefined();
     }
 
     if (rsaSize != sigLength) {
         // Sanity check. Shouldn't ever happen in practice.
-        ThrowException(Exception::Error(String::New("Shouldn't happen.")));
+        NanThrowError("Shouldn't happen.");
     }
 
-    return result->handle_;
+    NanReturnValue(result);
 }
 
 /**
@@ -929,22 +815,24 @@ Handle<Value> RsaWrap::Sign(const Arguments& args) {
  * what kind of hash was performed. Throws an exception if the signature
  * did not verify.
  */
-Handle<Value> RsaWrap::Verify(const Arguments& args) {
-    HandleScope scope;
+NAN_METHOD(RsaWrap::Verify) {
+    NanScope();
 
-    RsaWrap *obj = unwrapExpectSet(args);
-    if (obj == NULL) { return Undefined(); }
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectSet(obj);
+    if (obj == NULL) { NanReturnUndefined(); }
 
-    int nid;
-    if (!getArgInt(args, 0, &nid)) { return Undefined(); }
+    int nid = args[0]->Uint32Value();
 
-    int dataLength;
-    void *data = getArgDataAndLength(args, 1, &dataLength);
-    if (data == NULL) { return Undefined(); }
+    Local<Object> buffer = args[1].As<Object>();
+    size_t dataLength = node::Buffer::Length(buffer);
+    char* data = node::Buffer::Data(buffer);
+    if (data == NULL) { NanReturnUndefined(); }
 
-    int sigLength;
-    void *sig = getArgDataAndLength(args, 2, &sigLength);
-    if (sig == NULL) { return Undefined(); }
+    Local<Object> sigBuffer = args[2].As<Object>();
+    size_t sigLength = node::Buffer::Length(sigBuffer);
+    char* sig = node::Buffer::Data(sigBuffer);
+    if (sig == NULL) { NanReturnUndefined(); }
 
     int ret = RSA_verify(nid, (unsigned char *) data, dataLength,
                          (unsigned char *) sig, sigLength, obj->rsa);
@@ -958,23 +846,24 @@ Handle<Value> RsaWrap::Verify(const Arguments& args) {
             // (as opposed to, say, a more dire failure in the library
             // warranting an exception throw).
             ERR_get_error(); // Consume the error (get it off the err stack).
-            return False();
+            NanReturnValue(NanFalse());
         }
         scheduleSslException();
     }
 
-    return True();
+    NanReturnValue(NanTrue());
 }
 
-Handle<Value> RsaWrap::CreatePrivateKeyFromComponents(const Arguments& args) {
-    RsaWrap *obj = unwrapExpectUnset(args);
+NAN_METHOD(RsaWrap::CreatePrivateKeyFromComponents) {
+    RsaWrap *obj = ObjectWrap::Unwrap<RsaWrap>(args.Holder());
+    expectUnset(obj);
     if (obj == NULL) {
-        return Undefined();
+        NanReturnUndefined();
     }
 
     obj->rsa = RSA_new();
     if (obj->rsa == NULL) {
-        return Undefined();
+        NanReturnUndefined();
     }
 
     BIGNUM *modulus;
@@ -988,34 +877,34 @@ Handle<Value> RsaWrap::CreatePrivateKeyFromComponents(const Arguments& args) {
 
     bool ok = true;
 
-    modulus = getArgXBigNum(0, args);
+    modulus = getArgXBigNum(args[0].As<Object>());
     ok &= (modulus != NULL);
     if (ok) {
-        exponent = getArgXBigNum(1, args);
+        exponent = getArgXBigNum(args[1].As<Object>());
         ok &= (exponent != NULL);
     }
     if (ok) {
-        p = getArgXBigNum(2, args);
+        p = getArgXBigNum(args[2].As<Object>());
         ok &= (p != NULL);
     }
     if (ok) {
-        q = getArgXBigNum(3, args);
+        q = getArgXBigNum(args[3].As<Object>());
         ok &= (q != NULL);
     }
     if (ok) {
-        dp = getArgXBigNum(4, args);
+        dp = getArgXBigNum(args[4].As<Object>());
         ok &= (dp != NULL);
     }
     if (ok) {
-        dq = getArgXBigNum(5, args);
+        dq = getArgXBigNum(args[5].As<Object>());
         ok &= (dq != NULL);
     }
     if (ok) {
-        inverseQ = getArgXBigNum(6, args);
+        inverseQ = getArgXBigNum(args[6].As<Object>());
         ok &= (inverseQ != NULL);
     }
     if (ok) {
-        d = getArgXBigNum(7, args);
+        d = getArgXBigNum(args[7].As<Object>());
         ok &= (d != NULL);
     }
 
@@ -1039,5 +928,5 @@ Handle<Value> RsaWrap::CreatePrivateKeyFromComponents(const Arguments& args) {
         BN_free(d);
     }
 
-    return Undefined();
+    NanReturnUndefined();
 }

--- a/src/ursaNative.h
+++ b/src/ursaNative.h
@@ -7,6 +7,7 @@
 #define BUILDING_NODE_EXTENSION
 #endif
 #include <node.h>
+#include <nan.h>
 #include <v8.h>
 
 #include <openssl/rsa.h>

--- a/src/ursaNative.h
+++ b/src/ursaNative.h
@@ -12,7 +12,7 @@
 
 #include <openssl/rsa.h>
 
-class RsaWrap : node::ObjectWrap {
+class RsaWrap : public node::ObjectWrap {
   public:
     static void InitClass(v8::Handle<v8::Object> target);
 
@@ -20,31 +20,31 @@ class RsaWrap : node::ObjectWrap {
     RsaWrap();
     ~RsaWrap();
 
-    static v8::Handle<v8::Value> New(const v8::Arguments& args);
-    static v8::Handle<v8::Value> GeneratePrivateKey(const v8::Arguments& args);
-    static v8::Handle<v8::Value> GetExponent(const v8::Arguments& args);
-    static v8::Handle<v8::Value> GetModulus(const v8::Arguments& args);
-    static v8::Handle<v8::Value> GetPrivateKeyPem(const v8::Arguments& args);
-    static v8::Handle<v8::Value> GetPublicKeyPem(const v8::Arguments& args);
-    static v8::Handle<v8::Value> PrivateDecrypt(const v8::Arguments& args);
-    static v8::Handle<v8::Value> PrivateEncrypt(const v8::Arguments& args);
-    static v8::Handle<v8::Value> PublicDecrypt(const v8::Arguments& args);
-    static v8::Handle<v8::Value> PublicEncrypt(const v8::Arguments& args);
-    static v8::Handle<v8::Value> SetPrivateKeyPem(const v8::Arguments& args);
-    static v8::Handle<v8::Value> SetPublicKeyPem(const v8::Arguments& args);
-    static v8::Handle<v8::Value> Sign(const v8::Arguments& args);
-    static v8::Handle<v8::Value> Verify(const v8::Arguments& args);
-    static v8::Handle<v8::Value> CreatePrivateKeyFromComponents(const v8::Arguments& args);
-    static v8::Handle<v8::Value> OpenPublicSshKey(const v8::Arguments& args);
+    static NAN_METHOD(New);
+    static NAN_METHOD(GeneratePrivateKey);
+    static NAN_METHOD(GetExponent);
+    static NAN_METHOD(GetModulus);
+    static NAN_METHOD(GetPrivateKeyPem);
+    static NAN_METHOD(GetPublicKeyPem);
+    static NAN_METHOD(PrivateDecrypt);
+    static NAN_METHOD(PrivateEncrypt);
+    static NAN_METHOD(PublicDecrypt);
+    static NAN_METHOD(PublicEncrypt);
+    static NAN_METHOD(SetPrivateKeyPem);
+    static NAN_METHOD(SetPublicKeyPem);
+    static NAN_METHOD(Sign);
+    static NAN_METHOD(Verify);
+    static NAN_METHOD(CreatePrivateKeyFromComponents);
+    static NAN_METHOD(OpenPublicSshKey);
 
   private:
-    static RsaWrap *unwrapExpectPrivateKey(const v8::Arguments& args);
-    static RsaWrap *unwrapExpectSet(const v8::Arguments& args);
-    static RsaWrap *unwrapExpectUnset(const v8::Arguments& args);
+    static RsaWrap *expectPrivateKey(RsaWrap* obj);
+    static RsaWrap *expectSet(RsaWrap* obj);
+    static RsaWrap *expectUnset(RsaWrap* obj);
 
     RSA *rsa;
 };
 
-v8::Handle<v8::Value> TextToNid(const v8::Arguments& args);
+NAN_METHOD(TextToNid);
 
 #endif // def URSA_NATIVE_H

--- a/test/native.js
+++ b/test/native.js
@@ -218,8 +218,8 @@ function test_privateDecrypt() {
     var decoded = rsa.privateDecrypt(encoded, ursaNative.RSA_PKCS1_OAEP_PADDING).toString(fixture.UTF8);
     assert.equal(decoded, fixture.PLAINTEXT);
 
-    var encoded = new Buffer(fixture.PRIVATE_OLD_PAD_CIPHER_HEX, fixture.HEX);
-    var decoded = rsa.privateDecrypt(encoded, ursaNative.RSA_PKCS1_PADDING).toString(fixture.UTF8);
+    encoded = new Buffer(fixture.PRIVATE_OLD_PAD_CIPHER_HEX, fixture.HEX);
+    decoded = rsa.privateDecrypt(encoded, ursaNative.RSA_PKCS1_PADDING).toString(fixture.UTF8);
     assert.equal(decoded, fixture.PLAINTEXT);
 }
 
@@ -270,8 +270,8 @@ function test_publicEncrypt() {
     assert.equal(decoded, fixture.PLAINTEXT);
 
     // Test with old-style padding.
-    var encoded = rsa.publicEncrypt(plainBuf, ursaNative.RSA_PKCS1_PADDING);
-    var decoded = priv.privateDecrypt(encoded, ursaNative.RSA_PKCS1_PADDING);
+    encoded = rsa.publicEncrypt(plainBuf, ursaNative.RSA_PKCS1_PADDING);
+    decoded = priv.privateDecrypt(encoded, ursaNative.RSA_PKCS1_PADDING);
     decoded = decoded.toString(fixture.UTF8);
     assert.equal(decoded, fixture.PLAINTEXT);
 }
@@ -392,7 +392,7 @@ function test_generatePrivateKey() {
     encoded = pubKey.publicEncrypt(plainBuf, ursaNative.RSA_PKCS1_OAEP_PADDING);
     decoded = rsa.privateDecrypt(encoded, ursaNative.RSA_PKCS1_OAEP_PADDING).toString(fixture.UTF8);
     assert.equal(decoded, fixture.PLAINTEXT);
-    
+
     // Similarly, try decoding with an extracted private key.
     var privKey = new RsaWrap();
     privKey.setPrivateKeyPem(rsa.getPrivateKeyPem());


### PR DESCRIPTION
This fixes issue #73. 

Tests pass on node 0.10, node 0.11, and io.js: https://travis-ci.org/ceejbot/ursa/builds/49882604
Passing on node 0.11 should cover 0.12 though that should be bumped as soon as Travis can test on 0.12 directly.

- Added dependency on NAN & wrapped all changed APIs with NAN macros.
- Added a `.travis.yml` for automated testing across versions if you'd like to enable that.
- Fixed a couple of minor problems caught by jshint in the test code; no functional changes.