### PR TITLE
Have the `update(...)` method of Signer and Verifier to return `this`.

### DIFF
--- a/lib/ursa.js
+++ b/lib/ursa.js
@@ -670,10 +670,12 @@ function equalKeys(key1, key2) {
  */
 function createSigner(algorithm) {
     var hash = crypto.createHash(algorithm);
+    var self = {};
 
     function update(buf, bufEncoding) {
         buf = decodeString(buf, bufEncoding);
         hash.update(buf);
+        return self;
     }
 
     function sign(privateKey, outEncoding) {
@@ -681,10 +683,9 @@ function createSigner(algorithm) {
         return privateKey.sign(algorithm, hashBuf, undefined, outEncoding);
     }
 
-    return {
-        sign:   sign,
-        update: update
-    };
+    self.sign = sign;
+    self.update = update;
+    return self;
 }
 
 /**
@@ -692,10 +693,12 @@ function createSigner(algorithm) {
  */
 function createVerifier(algorithm) {
     var hash = crypto.createHash(algorithm);
+    var self = {};
 
     function update(buf, bufEncoding) {
         buf = decodeString(buf, bufEncoding);
         hash.update(buf);
+        return self;
     }
 
     function verify(publicKey, sig, sigEncoding) {
@@ -704,10 +707,9 @@ function createVerifier(algorithm) {
         return publicKey.verify(algorithm, hashBuf, sig);
     }
 
-    return {
-        update: update,
-        verify: verify
-    };
+    self.update = update;
+    self.verify = verify;
+    return self;
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -278,7 +278,7 @@ function testTypes() {
     var pub = ursa.createPublicKey(fixture.PUBLIC_KEY);
     var priv = ursa.createPrivateKey(fixture.PRIVATE_KEY);
     var msg;
-    
+
     msg = "Problem with isKey()";
     assert.equal(ursa.isKey(pub),       true,  msg);
     assert.equal(ursa.isKey(priv),      true,  msg);
@@ -514,7 +514,7 @@ function test_sshFingerprint() {
     assert.equal(finger, fixture.SSH_PUBLIC_KEY_FINGERPRINT_HEX);
 
     finger = ursa.sshFingerprint(
-        fixture.SSH_PUBLIC_KEY.toString(fixture.BASE64), 
+        fixture.SSH_PUBLIC_KEY.toString(fixture.BASE64),
         fixture.BASE64, fixture.HEX);
     assert.equal(finger, fixture.SSH_PUBLIC_KEY_FINGERPRINT_HEX);
 }
@@ -577,7 +577,8 @@ function testSigner() {
     var key = ursa.createPrivateKey(fixture.PRIVATE_KEY);
     var signer = ursa.createSigner(fixture.SHA256);
 
-    signer.update(fixture.PLAINTEXT, fixture.UTF8);
+    var ret = signer.update(fixture.PLAINTEXT, fixture.UTF8);
+    assert.equal(ret === signer, true);
 
     var sig = signer.sign(key, fixture.HEX);
 
@@ -587,7 +588,11 @@ function testSigner() {
 function testVerifier() {
     var key = ursa.createPublicKey(fixture.PUBLIC_KEY);
     var verifier = ursa.createVerifier(fixture.SHA256);
-    verifier.update(fixture.PLAINTEXT, fixture.UTF8);
+
+    var ret = verifier.update(fixture.PLAINTEXT, fixture.UTF8);
+    assert.equal(ret === verifier, true);
+
+
     assert.equal(verifier.verify(key, fixture.PLAINTEXT_SHA256_SIGNATURE,
                                  fixture.HEX),
                  true);


### PR DESCRIPTION
This helps with method chaining, like:

```javascript
var signature = ursa.createSigner('SHA256')
                    .update('foo')
                    .update('bar')
                    .sign(...);
```

Fixes quartzjer/ursa#86