### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,7 @@
     "type": "git",
     "url": "https://github.com/quartzjer/ursa.git"
   },
-  "licenses": [
-    {
-      "type": "Apache 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ],
+  "license": "Apache-2.0",
   "author": {
     "name": "Dan Bornstein",
     "email": "danfuzz@milk.com",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/