### PR TITLE
[FYI] quick hack for switching to nan-2.0.9 for node-4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.10"
-  - iojs
+  - "4.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^1.7.0"
+    "nan": "^2.0.9"
   }
 }

--- a/src/ursaNative.cc
+++ b/src/ursaNative.cc
@@ -32,8 +32,19 @@ Persistent<Function> constructor;
  * Helper for prototype binding.
  */
 #define BIND(proto, highName, lowName) \
-    (proto)->Set(NanNew<String>(#highName), \
-        NanNew<FunctionTemplate>(lowName)->GetFunction())
+    (proto)->Set(Nan::New(#highName).ToLocalChecked(), \
+        Nan::New<FunctionTemplate>(lowName)->GetFunction())
+
+#define NanThrowError(err) Nan::ThrowError(err);
+#define NanNewBufferHandle(length) Nan::NewBuffer(length).ToLocalChecked()
+#define NanUndefined() Nan::Undefined()
+#define args info
+#define NanScope() Nan::HandleScope scope
+#define NanReturnUndefined() info.GetReturnValue().Set(Nan::Undefined())
+#define NanNew Nan::New
+#define NanReturnValue(value) info.GetReturnValue().Set(value);
+#define NanFalse() Nan::False()
+#define NanTrue() Nan::True()
 
 #define RSA_PKCS1_SALT_LEN_HLEN    -1
 #define RSA_PKCS1_SALT_LEN_MAX     -2
@@ -307,7 +318,7 @@ NAN_METHOD(TextToNid) {
  * Initialize the bindings for this class.
  */
 void RsaWrap::InitClass(Handle<Object> target) {
-    Local<String> className = NanNew<String>("RsaWrap");
+    Local<String> className = NanNew("RsaWrap").ToLocalChecked();
 
     // Basic instance setup
     Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(New);
@@ -339,8 +350,8 @@ void RsaWrap::InitClass(Handle<Object> target) {
     BIND(proto, verifyPSSPadding,   VerifyPSSPadding);
 
     // Store the constructor in the target bindings.
-    target->Set(NanNew("RsaWrap"), tpl->GetFunction());
-    NanAssignPersistent<Function>(constructor, tpl->GetFunction());
+    target->Set(NanNew("RsaWrap").ToLocalChecked(), tpl->GetFunction());
+    constructor.Reset(target->GetIsolate(), tpl->GetFunction());
 }
 
 /**


### PR DESCRIPTION
I made a quick patch for updating to nan-2.0.9 for running on nodejs-4

"npm test" not passed, but the ursa module works as

- `ursa.generatePrivateKey`
- `priv.toPublicPem`
- `ursa.createPublicKey`
- `pub.encrypt`
- `priv.decrypt`

