### PR TITLE
Issue #128 Changed minimum node engine to >= 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ursa",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "keywords": [
     "crypto",
     "key",
@@ -36,7 +36,7 @@
   ],
   "main": "lib/ursa.js",
   "engine": {
-    "node": ">=0.6.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
     "test": "node test/test.js"


### PR DESCRIPTION
Resolve [Issue 128](https://github.com/quartzjer/ursa/issues/128)

ursa@0.8.5 works for node 0.8 but not higher
ursa@0.9.1 works for node 0.10 and up

This change captures these constraints in the engine section of package.json

