### PR TITLE
Add link to ursa-purejs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Other Repos that may be of Interest:
 
 * https://github.com/mal/forsake
 * https://github.com/rzcoder/node-rsa
+* https://github.com/roblabla/ursa-purejs
 * https://github.com/coolaj86/nodejs-self-signed-certificate-example
 * https://github.com/coolaj86/node-ssl-root-cas/wiki/Painless-Self-Signed-Certificates-in-node.js
 * https://github.com/coolaj86/node-ssl-root-cas


### PR DESCRIPTION
I've been having a hard time with an app that uses ursa in a Docker container because of the OpenSSL dependency (specifically nan was giving me issues) so I switched it out for ursa-purejs, so I don't need to rewrite everything to work with node-rsa.

Anyway, ursa-purejs was somehow surprisingly difficult to find, so I figure a link in the "other repos of interest" section would be in order, for anybody finding themselves in a similar predicament.