### PR TITLE
Simplify binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,36 +3,9 @@
     {
       'target_name': 'ursaNative',
       'sources': [ 'src/ursaNative.cc' ],
-      'conditions': [
-        [ 'OS=="win"', {
-          'conditions': [
-            # "openssl_root" is the directory on Windows of the OpenSSL files
-            ['target_arch=="x64"', {
-              'variables': {
-                'openssl_root%': 'C:/OpenSSL-Win64'
-              },
-            }, {
-              'variables': {
-                'openssl_root%': 'C:/OpenSSL-Win32'
-              },
-            }],
-          ],
-          'defines': [
-            'uint=unsigned int',
-          ],
-          'libraries': [ 
-            '-l<(openssl_root)/lib/libeay32.lib',
-          ],
-          'include_dirs': [
-            '<(openssl_root)/include',
-                        "<!(node -e \"require('nan')\")"
-          ],
-        }, { # OS!="win"
-          'include_dirs': [
-            "<!(node -e \"require('nan')\")"
-          ],
-        }],
-      ],
+      'include_dirs': [
+        "<!(node -e \"require('nan')\")"
+      ]
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,9 +29,7 @@
           ],
         }, { # OS!="win"
           'include_dirs': [
-            # use node's bundled openssl headers on Unix platforms
-            '<(node_root_dir)/deps/openssl/openssl/include',
-                        "<!(node -e \"require('nan')\")"
+            "<!(node -e \"require('nan')\")"
           ],
         }],
       ],

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^2.3.3"
+    "nan": "^2.4.0"
   }
 }


### PR DESCRIPTION
On Windows, Node 6.3.0 exports the OpenSSL symbols which means we don't have to look for them. It also means we don't have hassle when OpenSSL change their library names as happened in 1.1.0.

Note if this change goes in then on Windows ursa would require Node 6.3.0 or above.
I'm not sure whether this would be an acceptable price to pay for more reliable Windows support going forward.
 